### PR TITLE
Fix Windows chooser crashes and bundle icon assets into MSI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -73,6 +73,8 @@ jobs:
           }
           Write-Host "Copying exe: $exe"
           Copy-Item $exe $bundleDir -Force
+          Copy-Item (Join-Path $workspace 'data\keycord.ico') $bundleDir -Force
+          Copy-Item (Join-Path $workspace 'data\256x256\apps\io.github.noobping.keycord.png') $bundleDir -Force
           $mingwBin = 'C:\tools\msys64\mingw64\bin'
           if (-not (Test-Path $mingwBin)) {
            Write-Error "MinGW bin dir not found: $mingwBin"

--- a/build.rs
+++ b/build.rs
@@ -997,7 +997,10 @@ fn collect_svg_icons(dir: &Path, data_dir: &Path, icons: &mut Vec<String>) {
 
         if path.is_dir() {
             collect_svg_icons(&path, data_dir, icons);
-        } else if path.extension().and_then(|value| value.to_str()) == Some("svg") {
+        } else if matches!(
+            path.extension().and_then(|value| value.to_str()),
+            Some("svg" | "png")
+        ) {
             let rel = path
                 .strip_prefix(data_dir)
                 .expect("Resource path should stay within data/");

--- a/data/keycord.wxs
+++ b/data/keycord.wxs
@@ -16,6 +16,8 @@
 
         <MajorUpgrade DowngradeErrorMessage="A newer version is already installed." />
         <MediaTemplate EmbedCab="yes" />
+        <Icon Id="AppIconIco" SourceFile="$(var.BundleDir)\keycord.ico" />
+        <Property Id="ARPPRODUCTICON" Value="AppIconIco" />
 
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFilesFolder">
@@ -29,6 +31,7 @@
                         Name="$(var.ProductName)"
                         Description="Launch $(var.ProductName)"
                         Target="[INSTALLDIR]$(var.ExecutableName).exe"
+                        Icon="AppIconIco"
                         WorkingDirectory="INSTALLDIR" />
                     <RemoveFolder Id="CleanUpStartMenu" Directory="ApplicationProgramsFolder" On="uninstall" />
                     <RegistryValue

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,13 @@ const SEQUOIA_OPENPGP_VERSION: &str = env!("SEQUOIA_OPENPGP_VERSION");
 const SHORTCUTS_UI: &str = include_str!("../data/shortcuts.ui");
 
 fn main() -> ExitCode {
+    #[cfg(target_os = "windows")]
+    {
+        // Force GTK to use the native Windows chooser instead of xdg-desktop-portal.
+        // Portal backends are Linux-specific and can crash under Windows environments.
+        std::env::set_var("GTK_USE_PORTAL", "0");
+    }
+
     #[cfg(target_os = "linux")]
     {
         let args = std::env::args_os().collect::<Vec<_>>();

--- a/src/store/management.rs
+++ b/src/store/management.rs
@@ -25,7 +25,7 @@ use crate::support::ui::{
     append_action_row_with_button, append_info_row, clear_list_box, dim_label_icon,
     flat_icon_button,
 };
-use adw::gtk::{FileChooserAction, FileChooserNative, ListBox, ResponseType};
+use adw::gtk::{FileChooserAction, FileChooserDialog, ListBox, ResponseType};
 use adw::prelude::*;
 use adw::{ActionRow, ApplicationWindow, Toast, ToastOverlay};
 use std::fs;
@@ -61,7 +61,7 @@ fn initial_recipients_for_store_creation(
     }
 }
 
-fn selected_local_folder(dialog: &FileChooserNative, overlay: &ToastOverlay) -> Option<String> {
+fn selected_local_folder(dialog: &FileChooserDialog, overlay: &ToastOverlay) -> Option<String> {
     let file = dialog.file()?;
     let path = file.path().or_else(|| {
         log_error(
@@ -83,13 +83,14 @@ fn open_store_folder_picker(
     overlay: &ToastOverlay,
     on_selected: impl Fn(String) + 'static,
 ) {
-    let dialog = FileChooserNative::new(
+    let dialog = FileChooserDialog::new(
         Some(&gettext(title)),
         Some(window),
         FileChooserAction::SelectFolder,
-        Some(&gettext(accept_label)),
-        Some(&gettext("Cancel")),
+        &[],
     );
+    dialog.add_button(&gettext("Cancel"), ResponseType::Cancel);
+    dialog.add_button(&gettext(accept_label), ResponseType::Accept);
     dialog.set_create_folders(create_folders);
 
     let overlay = overlay.clone();

--- a/src/store/management/import.rs
+++ b/src/store/management/import.rs
@@ -17,7 +17,7 @@ use crate::window::navigation::{
     show_secondary_page_chrome, HasWindowChrome, WindowNavigationState,
 };
 use adw::gtk::{
-    Button, FileChooserAction, FileChooserNative, Image, ListBox, ResponseType, ScrolledWindow,
+    Button, FileChooserAction, FileChooserDialog, Image, ListBox, ResponseType, ScrolledWindow,
     Stack,
 };
 use adw::prelude::*;
@@ -127,7 +127,7 @@ impl PassImportRowState {
     }
 }
 
-fn selected_local_path(dialog: &FileChooserNative, overlay: &ToastOverlay) -> Option<String> {
+fn selected_local_path(dialog: &FileChooserDialog, overlay: &ToastOverlay) -> Option<String> {
     let file = dialog.file()?;
     let path = file.path().or_else(|| {
         log_error(
@@ -336,13 +336,14 @@ pub fn initialize_store_import_page(state: &StoreImportPageState) {
     {
         let state = state.clone();
         state.source_file_button.connect_clicked(move |_| {
-            let dialog = FileChooserNative::new(
+            let dialog = FileChooserDialog::new(
                 Some(&gettext("Choose import source file")),
                 Some(&state.window),
                 FileChooserAction::Open,
-                Some(&gettext("Select")),
-                Some(&gettext("Cancel")),
+                &[],
             );
+            dialog.add_button(&gettext("Cancel"), ResponseType::Cancel);
+            dialog.add_button(&gettext("Select"), ResponseType::Accept);
             let overlay = state.overlay.clone();
             let source_path = state.source_path.clone();
             let source_path_row = state.source_path_row.clone();
@@ -362,13 +363,14 @@ pub fn initialize_store_import_page(state: &StoreImportPageState) {
     {
         let state = state.clone();
         state.source_folder_button.connect_clicked(move |_| {
-            let dialog = FileChooserNative::new(
+            let dialog = FileChooserDialog::new(
                 Some(&gettext("Choose import source folder")),
                 Some(&state.window),
                 FileChooserAction::SelectFolder,
-                Some(&gettext("Select")),
-                Some(&gettext("Cancel")),
+                &[],
             );
+            dialog.add_button(&gettext("Cancel"), ResponseType::Cancel);
+            dialog.add_button(&gettext("Select"), ResponseType::Accept);
             let overlay = state.overlay.clone();
             let source_path = state.source_path.clone();
             let source_path_row = state.source_path_row.clone();

--- a/src/store/recipients_page/import.rs
+++ b/src/store/recipients_page/import.rs
@@ -15,7 +15,7 @@ use crate::support::actions::activate_widget_action;
 use crate::support::background::spawn_result_task;
 use crate::support::ui::connect_row_action;
 use adw::gio;
-use adw::gtk::{gdk::Display, FileChooserAction, FileChooserNative, ResponseType};
+use adw::gtk::{gdk::Display, FileChooserAction, FileChooserDialog, ResponseType};
 use adw::prelude::*;
 use adw::Toast;
 use std::rc::Rc;
@@ -205,13 +205,14 @@ fn open_hardware_public_key_picker(
     hardware: ManagedRipassoHardwareKey,
     title: &str,
 ) {
-    let dialog = FileChooserNative::new(
+    let dialog = FileChooserDialog::new(
         Some(&gettext(title)),
         Some(&state.window),
         FileChooserAction::Open,
-        Some(&gettext("Import")),
-        Some(&gettext("Cancel")),
+        &[],
     );
+    dialog.add_button(&gettext("Cancel"), ResponseType::Cancel);
+    dialog.add_button(&gettext("Import"), ResponseType::Accept);
     let state_for_response = state.clone();
     dialog.connect_response(move |dialog, response| {
         if response != ResponseType::Accept {
@@ -277,13 +278,14 @@ fn import_hardware_key_from_file(state: &StoreRecipientsPageState) {
 }
 
 fn open_private_key_picker(state: &StoreRecipientsPageState) {
-    let dialog = FileChooserNative::new(
+    let dialog = FileChooserDialog::new(
         Some(&gettext("Import private key")),
         Some(&state.window),
         FileChooserAction::Open,
-        Some(&gettext("Import")),
-        Some(&gettext("Cancel")),
+        &[],
     );
+    dialog.add_button(&gettext("Cancel"), ResponseType::Cancel);
+    dialog.add_button(&gettext("Import"), ResponseType::Accept);
     let state_for_response = state.clone();
     dialog.connect_response(move |dialog, response| {
         if response != ResponseType::Accept {


### PR DESCRIPTION
### Motivation
- Prevent app crashes on Windows caused by GTK selecting Linux portal backends when showing file choosers. 
- Ensure the app icon is available on Windows by providing a raster fallback and bundling icon assets into the installer. 
- Use a stable native dialog path on Windows instead of relying on portal behavior that is Linux-specific.

### Description
- Disable portal usage on Windows by setting `GTK_USE_PORTAL=0` at startup in `src/main.rs` so GTK will use native choosers there. 
- Replace `FileChooserNative` usages with `FileChooserDialog` and add explicit `Accept`/`Cancel` buttons in `src/store/management.rs`, `src/store/management/import.rs`, and `src/store/recipients_page/import.rs` so dialogs do not route through desktop portals on Windows. 
- Extend the resource collector in `build.rs` to include `png` files alongside `svg` so raster icons are added to the compiled resources as fallbacks. 
- Copy `data/keycord.ico` and `data/256x256/apps/io.github.noobping.keycord.png` into the Windows bundle in `.github/workflows/win.yml` so the MSI payload contains the icons. 
- Update the WiX template `data/keycord.wxs` to declare the bundled `.ico` as an `Icon` resource, set `ARPPRODUCTICON`, and apply it to the Start Menu shortcut. 
- Run `cargo fmt` to apply formatting changes.

### Testing
- `cargo fmt` executed successfully. 
- `cargo check` could not complete in this environment because system `glib-2.0` development files (the `glib-2.0.pc` pkg-config entry) are not available, causing the build to fail with a `pkg-config`/`glib-2.0` lookup error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5aeb2bc30832faf2d5652a25a2627)